### PR TITLE
Add HLINT hook with suggestions only

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -4,6 +4,12 @@
     entry: hlint
     language: system
     files: '\.l?hs$'
+-   id: hlint-suggestions
+    name: hlint
+    description: HLint gives suggestions on how to improve your source code, but still returns zero exti code.
+    entry: hlint --no-exit-code
+    language: system
+    files: '\.l?hs$'
 -   id: stylish-haskell
     name: stylish-haskell
     description: Haskell code prettifier.


### PR DESCRIPTION
Added a hook where the hlint command won't return a non-zero exit code on hints. Allowing the hlint suggestions to be shown, but not enforcing them.